### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: c
 
-os:
-  - linux
-  - osx
-
 matrix:
   include:
     - os: linux
@@ -23,6 +19,31 @@ matrix:
               - gcc-5
       env: COMPILER=gcc-5
     - compiler: gcc
+      addons:
+          apt:
+            sources:
+              - ubuntu-toolchain-r-test
+            packages:
+              - gcc-6
+      env: COMPILER=gcc-6
+#Added power jobs
+    - os: linux
+      arch: ppc64le
+      dist: trusty
+    - compiler: gcc
+      arch: ppc64le
+      env: COMPILER=gcc
+    - compiler: gcc
+      arch: ppc64le
+      addons:
+          apt:
+            sources:
+              - ubuntu-toolchain-r-test
+            packages:
+              - gcc-5
+      env: COMPILER=gcc-5
+    - compiler: gcc
+      arch: ppc64le
       addons:
           apt:
             sources:


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR and looks like its been successfully added.

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra