### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: c
+arch:
+  - amd64
+  - ppc64le
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,14 @@ matrix:
             packages:
               - gcc-6
       env: COMPILER=gcc-6
-      # added power support  
+      # added power support 
+    - os: linux
+      dist: trusty
+      arch: ppc64le
+    - os: osx
+      osx_image: xcode7.2
+    - os: osx
+      osx_image: xcode8.1
     - compiler: gcc
       env: COMPILER=gcc
       arch: ppc64le

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: c
-arch:
-  - amd64
-  - ppc64le
-
 os:
   - linux
   - osx
@@ -33,6 +29,28 @@ matrix:
             packages:
               - gcc-6
       env: COMPILER=gcc-6
+      # added power support  
+    - compiler: gcc
+      env: COMPILER=gcc
+      arch: ppc64le
+    - compiler: gcc
+      addons:
+          apt:
+            sources:
+              - ubuntu-toolchain-r-test
+            packages:
+              - gcc-5
+      env: COMPILER=gcc-5
+      arch: ppc64le
+    - compiler: gcc
+      addons:
+          apt:
+            sources:
+              - ubuntu-toolchain-r-test
+            packages:
+              - gcc-6
+      env: COMPILER=gcc-6
+      arch: ppc64le
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
     #- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install  ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: c
+arch:
+  - amd64
+  - ppc64le
 os:
   - linux
   - osx


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.